### PR TITLE
Fix ilvl calculation

### DIFF
--- a/ElvUI_Enhanced/Modules/Blizzard/CharacterFrame.lua
+++ b/ElvUI_Enhanced/Modules/Blizzard/CharacterFrame.lua
@@ -759,28 +759,36 @@ end
 ]]
 
 local function GetAverageItemLevel()
-	local items = 16
+	local items = 0
 	local ilvl = 0
+	counter = 0
 	local colorCount, sumR, sumG, sumB = 0, 0, 0, 0
 
-	for slotID = 1, 18 do
+	for slotID = 1, 16 do
+		counter = counter + 1
 		if slotID ~= INVSLOT_BODY then
 			local itemLink = GetInventoryItemLink("player", slotID)
 
 			if itemLink then
 				local _, _, quality, itemLevel, _, _, _, _, itemEquipLoc = GetItemInfo(itemLink)
-
 				if itemLevel then
-					ilvl = ilvl + itemLevel
+					if itemEquipLoc == "INVTYPE_2HWEAPON" then
+						items = items + 2
+						ilvl = ilvl + (itemLevel * 2)
+					else 
+						items = items + 1
+						ilvl = ilvl + itemLevel
+					end
 
 					colorCount = colorCount + 1
 					sumR = sumR + qualityColors[quality][1]
 					sumG = sumG + qualityColors[quality][2]
 					sumB = sumB + qualityColors[quality][3]
 
-					if slotID == INVSLOT_MAINHAND and (itemEquipLoc ~= "INVTYPE_2HWEAPON" or titanGrip) then
-						items = 17
-					end
+					--Irrelevant Titans Grip Calculation ??
+					--if slotID == INVSLOT_MAINHAND and (itemEquipLoc ~= "INVTYPE_2HWEAPON" or titanGrip) then
+					--	items = 17
+					--end
 				end
 			end
 		end

--- a/ElvUI_Enhanced/Modules/Blizzard/CharacterFrame.lua
+++ b/ElvUI_Enhanced/Modules/Blizzard/CharacterFrame.lua
@@ -764,7 +764,7 @@ local function GetAverageItemLevel()
 	counter = 0
 	local colorCount, sumR, sumG, sumB = 0, 0, 0, 0
 
-	for slotID = 1, 16 do
+	for slotID = 1, 17 do
 		counter = counter + 1
 		if slotID ~= INVSLOT_BODY then
 			local itemLink = GetInventoryItemLink("player", slotID)


### PR DESCRIPTION
I noticed the function was all kinds of fucked up. 

- removed titans grip check
- removed ranged slot relevance in calculation
- fixed two-handers being calculated with a shield